### PR TITLE
Upgrade to bevy 0.14, godot-ext 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ assets = [] # experimental feature, see assets::GodotResourceLoader
 
 [dependencies]
 anyhow = "1"
-bevy = { version = "0.13", default-features = false, features = ["bevy_asset"] }
-godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }
+bevy = { version = "0.14", default-features = false, features = ["bevy_asset"] }
+godot = "0.1.3"
 bevy_godot4_proc_macros = { path = "./proc_macros" }
 lazy_static = "1.4.0"
 send_wrapper = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ assets = [] # experimental feature, see assets::GodotResourceLoader
 
 [dependencies]
 anyhow = "1"
-bevy = { version = "0.10", default-features = false, features = ["bevy_asset"] }
-godot = { git = "https://github.com/godot-rust/gdext", rev = "885bb91926c76867093d85208b33aa80c87183b6" }
+bevy = { version = "0.13", default-features = false, features = ["bevy_asset"] }
+godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }
 bevy_godot4_proc_macros = { path = "./proc_macros" }
 lazy_static = "1.4.0"
 send_wrapper = "0.6"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The architecture in this crate mimics that of [bevy_godot](https://github.com/ra
 2. Add this line to your cargo dependencies (along with the godot dependency from GDExtension setup):
 ```
 [dependencies]
-godot = { git = "https://github.com/godot-rust/gdext", branch = "main" }
+godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }
 bevy_godot4 = { git = "https://github.com/jrockett6/bevy_godot4", branch = "main" }
 ```
 3. Create a function that takes a `&mut App` and builds your bevy app, and annotate it with `#[bevy_app]`:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Bevy_Godot4
 
-> **NOTICE**: This crate is currrently unmaintained, and due to changes in gdext's api it is pinned to an old version of gdext and only works with Godot 4.0
+<!-- > **NOTICE**: This crate is currrently unmaintained, and due to changes in gdext's api it is pinned to an old version of gdext and only works with Godot 4.0 -->
 
 Bring the design power of Bevy's ECS to the mature engine capabilities of Godot 4.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The architecture in this crate mimics that of [bevy_godot](https://github.com/ra
 2. Add this line to your cargo dependencies (along with the godot dependency from GDExtension setup):
 ```
 [dependencies]
-godot = { git = "https://github.com/godot-rust/gdext", rev = "885bb91926c76867093d85208b33aa80c87183b6" }
+godot = { git = "https://github.com/godot-rust/gdext", branch = "main" }
 bevy_godot4 = { git = "https://github.com/jrockett6/bevy_godot4", branch = "main" }
 ```
 3. Create a function that takes a `&mut App` and builds your bevy app, and annotate it with `#[bevy_app]`:

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -12,6 +12,9 @@ name = "simple"
 crate-type = ["cdylib"]
 
 [dependencies]
-bevy = { version = "0.13", default-features = false, features = ["bevy_asset"] }
+bevy = { version = "0.14.1", default-features = false, features = [
+    "bevy_asset",
+    "bevy_state",
+] }
 bevy_godot4 = { path = "../../../bevy_godot4" }
-godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }
+godot = "0.1.3"

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -12,6 +12,6 @@ name = "simple"
 crate-type = ["cdylib"]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = ["bevy_asset"] }
+bevy = { version = "0.13", default-features = false, features = ["bevy_asset"] }
 bevy_godot4 = { path = "../../../bevy_godot4" }
-godot = { git = "https://github.com/godot-rust/gdext", rev = "885bb91926c76867093d85208b33aa80c87183b6" }
+godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }

--- a/examples/simple/godot/project.godot
+++ b/examples/simple/godot/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Simple"
 run/main_scene="res://main.tscn"
-config/features=PackedStringArray("4.0", "Forward Plus")
+config/features=PackedStringArray("4.2", "Forward Plus")
 config/icon="res://icon.svg"
 
 [autoload]

--- a/examples/simple/godot/simple.gdextension
+++ b/examples/simple/godot/simple.gdextension
@@ -1,5 +1,6 @@
 [configuration]
 entry_symbol = "gdext_rust_init"
+compatibility_minimum = "4.1"
 
 [libraries]
 linux.debug.x86_64 = "res://../../target/debug/libsimple.so"

--- a/examples/simple/src/lib.rs
+++ b/examples/simple/src/lib.rs
@@ -1,6 +1,6 @@
 use bevy::ecs::prelude::*;
 use bevy_godot4::prelude::*;
-use godot::engine::{ResourceLoader, Sprite2D};
+use godot::classes::{ResourceLoader, Sprite2D};
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash, States)]
 enum GameState {

--- a/examples/simple/src/lib.rs
+++ b/examples/simple/src/lib.rs
@@ -1,6 +1,7 @@
 use bevy::ecs::prelude::*;
 use bevy_godot4::prelude::*;
 use godot::engine::{resource_loader::CacheMode, ResourceLoader, Sprite2D};
+use godot::prelude::*;
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash, States)]
 enum GameState {
@@ -10,10 +11,10 @@ enum GameState {
 
 #[bevy_app]
 fn build_app(app: &mut App) {
-    app.add_state::<GameState>()
+    app.init_state::<GameState>()
         .init_resource::<MyAssets>()
-        .add_system(spawn_sprite.in_schedule(OnEnter(GameState::Playing)))
-        .add_system(
+        .add_systems(OnEnter(GameState::Playing), spawn_sprite)
+        .add_systems(Update,
             move_sprite
                 .as_physics_system()
                 .run_if(in_state(GameState::Playing)),
@@ -30,7 +31,7 @@ impl Default for MyAssets {
         let mut resource_loader = ResourceLoader::singleton();
         let sprite = ErasedGdResource::new(
             resource_loader
-                .load("sprite.tscn".into(), "".into(), CacheMode::CACHE_MODE_REUSE)
+                .load("sprite.tscn".into())
                 .unwrap(),
         );
 

--- a/examples/simple/src/lib.rs
+++ b/examples/simple/src/lib.rs
@@ -1,6 +1,21 @@
-use bevy::ecs::prelude::*;
-use bevy_godot4::prelude::*;
-use godot::classes::{ResourceLoader, Sprite2D};
+use std::time::Duration;
+
+use bevy::{
+    app::{App, Update},
+    ecs::system::Res,
+    prelude::{
+        in_state, AppExtStates, Commands, IntoSystemConfigs, OnEnter, Query, Resource, States,
+    },
+    state::app::StatesPlugin,
+};
+use bevy_godot4::prelude::{
+    bevy_app, AsPhysicsSystem, ErasedGd, ErasedGdResource, GodotScene, SystemDeltaTimer,
+};
+use godot::{
+    builtin::Vector2,
+    classes::{ResourceLoader, Sprite2D},
+};
+use godot::{init::ExtensionLibrary, prelude::gdextension};
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash, States)]
 enum GameState {
@@ -10,10 +25,12 @@ enum GameState {
 
 #[bevy_app]
 fn build_app(app: &mut App) {
-    app.init_state::<GameState>()
+    app.add_plugins(StatesPlugin)
+        .init_state::<GameState>()
         .init_resource::<MyAssets>()
         .add_systems(OnEnter(GameState::Playing), spawn_sprite)
-        .add_systems(Update,
+        .add_systems(
+            Update,
             move_sprite
                 .as_physics_system()
                 .run_if(in_state(GameState::Playing)),
@@ -28,11 +45,7 @@ pub struct MyAssets {
 impl Default for MyAssets {
     fn default() -> Self {
         let mut resource_loader = ResourceLoader::singleton();
-        let sprite = ErasedGdResource::new(
-            resource_loader
-                .load("sprite.tscn".into())
-                .unwrap(),
-        );
+        let sprite = ErasedGdResource::new(resource_loader.load("sprite.tscn".into()).unwrap());
 
         Self { sprite }
     }

--- a/examples/simple/src/lib.rs
+++ b/examples/simple/src/lib.rs
@@ -1,7 +1,6 @@
 use bevy::ecs::prelude::*;
 use bevy_godot4::prelude::*;
-use godot::engine::{resource_loader::CacheMode, ResourceLoader, Sprite2D};
-use godot::prelude::*;
+use godot::engine::{ResourceLoader, Sprite2D};
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash, States)]
 enum GameState {

--- a/examples/simple/src/lib.rs
+++ b/examples/simple/src/lib.rs
@@ -1,4 +1,3 @@
-use std::time::Duration;
 
 use bevy::{
     app::{App, Update},

--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -12,11 +12,13 @@ pub fn bevy_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #[gdextension]
         unsafe impl ExtensionLibrary for BevyExtensionLibrary {
             fn on_level_init(level: bevy_godot4::prelude::InitLevel) {
-                bevy_godot4::godot::private::class_macros::auto_register_classes(level);
+                if level == bevy_godot4::prelude::InitLevel::Editor {
+                    bevy_godot4::godot::private::class_macros::auto_register_classes(level);
 
-                let mut app_builder_func = bevy_godot4::APP_BUILDER_FN.lock().unwrap();
-                if app_builder_func.is_none() {
-                    *app_builder_func = Some(Box::new(#name));
+                    let mut app_builder_func = bevy_godot4::APP_BUILDER_FN.lock().unwrap();
+                    if app_builder_func.is_none() {
+                        *app_builder_func = Some(Box::new(#name));
+                    }
                 }
             }
 

--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -13,7 +13,7 @@ pub fn bevy_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
         unsafe impl ExtensionLibrary for BevyExtensionLibrary {
             fn on_level_init(level: bevy_godot4::godot::prelude::InitLevel) {
                 if level == bevy_godot4::godot::prelude::InitLevel::Editor {
-                    bevy_godot4::godot::private::class_macros::auto_register_classes(level);
+                    bevy_godot4::godot::private::class_macros::registry::class::auto_register_classes(level);
 
                     let mut app_builder_func = bevy_godot4::APP_BUILDER_FN.lock().unwrap();
                     if app_builder_func.is_none() {

--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -11,8 +11,8 @@ pub fn bevy_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #[gdextension]
         unsafe impl ExtensionLibrary for BevyExtensionLibrary {
-            fn on_level_init(level: bevy_godot4::prelude::InitLevel) {
-                if level == bevy_godot4::prelude::InitLevel::Editor {
+            fn on_level_init(level: bevy_godot4::godot::prelude::InitLevel) {
+                if level == bevy_godot4::godot::prelude::InitLevel::Editor {
                     bevy_godot4::godot::private::class_macros::auto_register_classes(level);
 
                     let mut app_builder_func = bevy_godot4::APP_BUILDER_FN.lock().unwrap();

--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -11,17 +11,13 @@ pub fn bevy_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #[gdextension]
         unsafe impl ExtensionLibrary for BevyExtensionLibrary {
-            fn load_library(handle: &mut InitHandle) -> bool {
-                handle.register_layer(InitLevel::Scene, InitializationLayer);
-                true
-            }
-        }
+            // fn load_library(handle: &mut InitHandle) -> bool {
+            //     handle.register_layer(InitLevel::Scene, InitializationLayer);
+            //     true
+            // }
 
-        pub struct InitializationLayer;
-
-        impl ExtensionLayer for InitializationLayer {
-            fn initialize(&mut self) {
-                bevy_godot4::godot::private::class_macros::auto_register_classes();
+            fn on_level_init(level: bevy_godot4::prelude::InitLevel) {
+                bevy_godot4::godot::private::class_macros::auto_register_classes(level);
 
                 let mut app_builder_func = bevy_godot4::APP_BUILDER_FN.lock().unwrap();
                 if app_builder_func.is_none() {
@@ -29,8 +25,22 @@ pub fn bevy_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
             }
 
-            fn deinitialize(&mut self) {}
         }
+
+        // pub struct InitializationLayer;
+
+        // impl ExtensionLayer for InitializationLayer {
+        //     fn initialize(&mut self) {
+        //         bevy_godot4::godot::private::class_macros::auto_register_classes();
+
+        //         let mut app_builder_func = bevy_godot4::APP_BUILDER_FN.lock().unwrap();
+        //         if app_builder_func.is_none() {
+        //             *app_builder_func = Some(Box::new(#name));
+        //         }
+        //     }
+
+        //     fn deinitialize(&mut self) {}
+        // }
 
         #input_fn
 

--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -11,10 +11,9 @@ pub fn bevy_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #[gdextension]
         unsafe impl ExtensionLibrary for BevyExtensionLibrary {
-            fn on_level_init(level: bevy_godot4::godot::prelude::InitLevel) {
-                if level == bevy_godot4::godot::prelude::InitLevel::Editor {
-                    bevy_godot4::godot::private::class_macros::registry::class::auto_register_classes(level);
-
+            fn on_level_init(level: godot::prelude::InitLevel) {
+                if level == godot::prelude::InitLevel::Editor {
+                    godot::private::class_macros::registry::class::auto_register_classes(level);
                     let mut app_builder_func = bevy_godot4::APP_BUILDER_FN.lock().unwrap();
                     if app_builder_func.is_none() {
                         *app_builder_func = Some(Box::new(#name));

--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -11,11 +11,6 @@ pub fn bevy_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #[gdextension]
         unsafe impl ExtensionLibrary for BevyExtensionLibrary {
-            // fn load_library(handle: &mut InitHandle) -> bool {
-            //     handle.register_layer(InitLevel::Scene, InitializationLayer);
-            //     true
-            // }
-
             fn on_level_init(level: bevy_godot4::prelude::InitLevel) {
                 bevy_godot4::godot::private::class_macros::auto_register_classes(level);
 
@@ -26,21 +21,6 @@ pub fn bevy_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
 
         }
-
-        // pub struct InitializationLayer;
-
-        // impl ExtensionLayer for InitializationLayer {
-        //     fn initialize(&mut self) {
-        //         bevy_godot4::godot::private::class_macros::auto_register_classes();
-
-        //         let mut app_builder_func = bevy_godot4::APP_BUILDER_FN.lock().unwrap();
-        //         if app_builder_func.is_none() {
-        //             *app_builder_func = Some(Box::new(#name));
-        //         }
-        //     }
-
-        //     fn deinitialize(&mut self) {}
-        // }
 
         #input_fn
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,10 @@
+use bevy::app::App;
+use godot::{
+    classes::{INode, Node},
+    obj::Base,
+    prelude::{godot_api, GodotClass},
+};
+
 use crate::prelude::*;
 use std::{
     panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
@@ -71,7 +78,7 @@ impl INode for BevyApp {
                 resume_unwind(e);
             }
 
-            app.world.remove_resource::<GodotVisualFrame>();
+            app.world_mut().remove_resource::<GodotVisualFrame>();
         }
     }
 
@@ -90,7 +97,7 @@ impl INode for BevyApp {
                 resume_unwind(e);
             }
 
-            app.world.remove_resource::<GodotPhysicsFrame>();
+            app.world_mut().remove_resource::<GodotPhysicsFrame>();
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,7 +32,7 @@ impl INode for BevyApp {
     }
 
     fn ready(&mut self) {
-        if godot::engine::Engine::singleton().is_editor_hint() {
+        if godot::classes::Engine::singleton().is_editor_hint() {
             return;
         }
 
@@ -57,7 +57,7 @@ impl INode for BevyApp {
     }
 
     fn process(&mut self, _delta: f64) {
-        if godot::engine::Engine::singleton().is_editor_hint() {
+        if godot::classes::Engine::singleton().is_editor_hint() {
             return;
         }
 
@@ -76,7 +76,7 @@ impl INode for BevyApp {
     }
 
     fn physics_process(&mut self, _delta: f64) {
-        if godot::engine::Engine::singleton().is_editor_hint() {
+        if godot::classes::Engine::singleton().is_editor_hint() {
             return;
         }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,7 +26,7 @@ impl BevyApp {
 }
 
 #[godot_api]
-impl NodeVirtual for BevyApp {
+impl INode for BevyApp {
     fn init(_base: Base<Node>) -> Self {
         Default::default()
     }
@@ -38,20 +38,20 @@ impl NodeVirtual for BevyApp {
 
         let mut app = App::new();
         (APP_BUILDER_FN.lock().unwrap().as_mut().unwrap())(&mut app);
-        app.add_plugin(bevy::core::TaskPoolPlugin::default())
-            .add_plugin(bevy::log::LogPlugin::default())
-            .add_plugin(bevy::core::TypeRegistrationPlugin)
-            .add_plugin(bevy::core::FrameCountPlugin)
-            .add_plugin(bevy::diagnostic::DiagnosticsPlugin)
-            .add_plugin(bevy::time::TimePlugin)
-            .add_plugin(bevy::hierarchy::HierarchyPlugin)
-            .add_plugin(crate::scene::PackedScenePlugin)
+        app.add_plugins(bevy::core::TaskPoolPlugin::default())
+            .add_plugins(bevy::log::LogPlugin::default())
+            .add_plugins(bevy::core::TypeRegistrationPlugin)
+            .add_plugins(bevy::core::FrameCountPlugin)
+            .add_plugins(bevy::diagnostic::DiagnosticsPlugin)
+            .add_plugins(bevy::time::TimePlugin)
+            .add_plugins(bevy::hierarchy::HierarchyPlugin)
+            .add_plugins(crate::scene::PackedScenePlugin)
             .init_non_send_resource::<crate::scene_tree::SceneTreeRefImpl>();
-        // .add_plugin(GodotSignalsPlugin)
-        // .add_plugin(GodotInputEventPlugin);
+        // .add_plugins(GodotSignalsPlugin)
+        // .add_plugins(GodotInputEventPlugin);
 
         #[cfg(feature = "assets")]
-        app.add_plugin(crate::assets::GodotAssetsPlugin);
+        app.add_plugins(crate::assets::GodotAssetsPlugin);
 
         self.app = Some(app);
     }

--- a/src/erased_gd.rs
+++ b/src/erased_gd.rs
@@ -1,7 +1,9 @@
 use crate::prelude::*;
 use godot::{
-    engine::Resource, obj::{bounds::DynMemory, Bounds}, sys,
-    obj::RawGd
+    classes::Resource,
+    obj::RawGd,
+    obj::{bounds::DynMemory, Bounds},
+    sys,
 };
 
 #[derive(Debug, Component, Clone)]

--- a/src/erased_gd.rs
+++ b/src/erased_gd.rs
@@ -51,7 +51,7 @@ fn maybe_inc_ref<T: GodotClass>(gd: &Gd<T>) {
     <Object as Bounds>::DynMemory::maybe_inc_ref(&mut raw);
 }
 
-fn try_maybe_inc_ref<T: GodotClass>(gd: &Option<Gd<T>>) {
+fn maybe_inc_ref_opt<T: GodotClass>(gd: &Option<Gd<T>>) {
     if let Some(gd) = gd {
         let mygd: MyGd<T> = unsafe {
             std::mem::transmute(gd.clone())
@@ -71,7 +71,7 @@ fn maybe_dec_ref<T: GodotClass>(gd: &Gd<T>) -> bool {
     }
 }
 
-fn try_maybe_dec_ref<T: GodotClass>(gd: &Option<Gd<T>>) -> bool {
+fn maybe_dec_ref_opt<T: GodotClass>(gd: &Option<Gd<T>>) -> bool {
     if let Some(gd) = gd {
         let mygd: MyGd<T> = unsafe {
             std::mem::transmute(gd.clone())
@@ -109,7 +109,7 @@ impl Clone for ErasedGdResource {
         // StaticRefCount::maybe_inc_ref::<Resource>(
         //     &Gd::try_from_instance_id(self.resource_id).unwrap(),
         // );
-        try_maybe_inc_ref::<Resource>(&Gd::try_from_instance_id(self.resource_id).ok());
+        maybe_inc_ref_opt::<Resource>(&Gd::try_from_instance_id(self.resource_id).ok());
 
         Self {
             resource_id: self.resource_id.clone(),

--- a/src/erased_gd.rs
+++ b/src/erased_gd.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use godot::{
-    engine::Resource, obj::{bounds::{DynMemory, MemRefCounted, Memory}, Bounds}, sys,
+    engine::Resource, obj::{bounds::DynMemory, Bounds}, sys,
     obj::RawGd
 };
 

--- a/src/erased_gd.rs
+++ b/src/erased_gd.rs
@@ -63,15 +63,6 @@ fn maybe_dec_ref<T: GodotClass>(gd: &mut Gd<T>) -> bool {
     unsafe { <Object as Bounds>::DynMemory::maybe_dec_ref(&mut gd_.raw) }
 }
 
-fn maybe_dec_ref_opt<T: GodotClass>(gd: &mut Option<Gd<T>>) -> bool {
-    if let Some(gd) = gd {
-        let gd_: &mut Gd_<T> = unsafe { std::mem::transmute(gd) };
-        unsafe { <Object as Bounds>::DynMemory::maybe_dec_ref(&mut gd_.raw) }
-    } else {
-        false
-    }
-}
-
 impl ErasedGdResource {
     pub fn get(&mut self) -> Gd<Resource> {
         self.try_get().unwrap()

--- a/src/erased_gd.rs
+++ b/src/erased_gd.rs
@@ -1,8 +1,7 @@
-use crate::prelude::*;
+use bevy::prelude::Component;
 use godot::{
-    classes::Resource,
-    obj::RawGd,
-    obj::{bounds::DynMemory, Bounds},
+    classes::{Node, Object, Resource},
+    obj::{bounds::DynMemory, Bounds, Gd, GodotClass, Inherits, InstanceId, RawGd},
     sys,
 };
 
@@ -37,7 +36,7 @@ impl ErasedGd {
     }
 }
 
-#[derive(Debug, Resource)]
+#[derive(Debug, bevy::prelude::Resource)]
 pub struct ErasedGdResource {
     resource_id: InstanceId,
 }
@@ -48,38 +47,26 @@ struct Gd_<T: GodotClass> {
 }
 
 fn maybe_inc_ref<T: GodotClass>(gd: &mut Gd<T>) {
-    let gd_: &mut Gd_<T> = unsafe {
-        std::mem::transmute(gd)
-    };
+    let gd_: &mut Gd_<T> = unsafe { std::mem::transmute(gd) };
     <Object as Bounds>::DynMemory::maybe_inc_ref(&mut gd_.raw);
 }
 
 fn maybe_inc_ref_opt<T: GodotClass>(gd: &mut Option<Gd<T>>) {
     if let Some(gd) = gd {
-        let gd_: &mut Gd_<T> = unsafe {
-            std::mem::transmute(gd)
-        };
+        let gd_: &mut Gd_<T> = unsafe { std::mem::transmute(gd) };
         <Object as Bounds>::DynMemory::maybe_inc_ref(&mut gd_.raw);
     }
 }
 
 fn maybe_dec_ref<T: GodotClass>(gd: &mut Gd<T>) -> bool {
-    let gd_: &mut Gd_<T> = unsafe {
-        std::mem::transmute(gd)
-    };
-    unsafe {
-        <Object as Bounds>::DynMemory::maybe_dec_ref(&mut gd_.raw)
-    }
+    let gd_: &mut Gd_<T> = unsafe { std::mem::transmute(gd) };
+    unsafe { <Object as Bounds>::DynMemory::maybe_dec_ref(&mut gd_.raw) }
 }
 
 fn maybe_dec_ref_opt<T: GodotClass>(gd: &mut Option<Gd<T>>) -> bool {
     if let Some(gd) = gd {
-        let gd_: &mut Gd_<T> = unsafe {
-            std::mem::transmute(gd)
-        };
-        unsafe {
-            <Object as Bounds>::DynMemory::maybe_dec_ref(&mut gd_.raw)
-        }
+        let gd_: &mut Gd_<T> = unsafe { std::mem::transmute(gd) };
+        unsafe { <Object as Bounds>::DynMemory::maybe_dec_ref(&mut gd_.raw) }
     } else {
         false
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@ mod scene;
 mod scene_tree;
 mod utils;
 
-pub use bevy;
-pub use godot;
 pub mod prelude {
     pub use super::erased_gd::{ErasedGd, ErasedGdResource};
     pub use super::scene::GodotScene;
@@ -15,8 +13,6 @@ pub mod prelude {
     pub use super::utils::{
         AsPhysicsSystem, AsVisualSystem, GodotPhysicsFrame, GodotVisualFrame, SystemDeltaTimer,
     };
-    pub use bevy::prelude::*;
     pub use bevy_godot4_proc_macros::bevy_app;
-    pub use godot::prelude::*;
 }
 pub use app::{BevyApp, APP_BUILDER_FN};

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use crate::prelude::*;
 use bevy::utils::tracing;
-use godot::engine::ResourceLoader;
+use godot::classes::ResourceLoader;
 
 pub(crate) struct PackedScenePlugin;
 impl Plugin for PackedScenePlugin {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -2,9 +2,7 @@ use std::str::FromStr;
 
 use crate::prelude::*;
 use bevy::utils::tracing;
-use godot::engine::{
-    node::InternalMode, packed_scene::GenEditState, resource_loader::CacheMode, ResourceLoader,
-};
+use godot::engine::ResourceLoader;
 
 pub(crate) struct PackedScenePlugin;
 impl Plugin for PackedScenePlugin {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -7,7 +7,7 @@ use godot::engine::{
 pub(crate) struct PackedScenePlugin;
 impl Plugin for PackedScenePlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(spawn_scene.in_base_set(CoreSet::PostUpdate));
+        app.add_systems(spawn_scene.in_base_set(CoreSet::PostUpdate));
     }
 }
 

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,8 +1,15 @@
 use std::str::FromStr;
 
 use crate::prelude::*;
-use bevy::utils::tracing;
-use godot::classes::ResourceLoader;
+use bevy::{
+    app::{App, Plugin, PostUpdate},
+    prelude::{Commands, Component, Entity, Query, Without},
+    utils::tracing,
+};
+use godot::{
+    builtin::{GString, Transform2D, Transform3D, Vector2, Vector3},
+    classes::{Node2D, Node3D, PackedScene, ResourceLoader},
+};
 
 pub(crate) struct PackedScenePlugin;
 impl Plugin for PackedScenePlugin {
@@ -104,9 +111,7 @@ fn spawn_scene(
         let packed_scene = match &mut scene.resource {
             GodotSceneResource::Resource(res) => res.get(),
             GodotSceneResource::Path(path) => ResourceLoader::singleton()
-                .load(
-                    GString::from_str(path).expect("path to be a valid GString"),
-                )
+                .load(GString::from_str(path).expect("path to be a valid GString"))
                 .expect("packed scene to load"),
             #[cfg(feature = "assets")]
             GodotSceneResource::Handle(handle) => assets
@@ -127,9 +132,7 @@ fn spawn_scene(
             .unwrap()
             .get_node_or_null("BevyAppSingleton".into())
         {
-            Some(mut app) => app.add_child(
-                instance.clone(),
-            ),
+            Some(mut app) => app.add_child(instance.clone()),
             None => {
                 tracing::error!("attempted to add a child to the BevyAppSingleton autoload, but the BevyAppSingleton autoload wasn't found");
                 return;

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::prelude::*;
 use bevy::utils::tracing;
 use godot::engine::{
@@ -7,7 +9,7 @@ use godot::engine::{
 pub(crate) struct PackedScenePlugin;
 impl Plugin for PackedScenePlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(spawn_scene.in_base_set(CoreSet::PostUpdate));
+        app.add_systems(PostUpdate, spawn_scene);
     }
 }
 
@@ -105,9 +107,11 @@ fn spawn_scene(
             GodotSceneResource::Resource(res) => res.get(),
             GodotSceneResource::Path(path) => ResourceLoader::singleton()
                 .load(
-                    path.into(),
-                    "PackedScene".into(),
-                    CacheMode::CACHE_MODE_REUSE,
+                    // path.into(),
+                    // "PackedScene".into(),
+                    GString::from_str(path).expect("path to be a valid GString"),
+                    // // CacheMode::CACHE_MODE_REUSE,
+                    // CacheMode::REUSE,
                 )
                 .expect("packed scene to load"),
             #[cfg(feature = "assets")]
@@ -120,19 +124,18 @@ fn spawn_scene(
         let instance = packed_scene
             .try_cast::<PackedScene>()
             .expect("resource to be a packed scene")
-            .instantiate(GenEditState::GEN_EDIT_STATE_DISABLED)
+            // .instantiate(GenEditState::GEN_EDIT_STATE_DISABLED)
+            .instantiate()
             .unwrap();
 
         match scene_tree
             .get()
             .get_root()
             .unwrap()
-            .get_node("BevyAppSingleton".into())
+            .get_node_or_null("BevyAppSingleton".into())
         {
             Some(mut app) => app.add_child(
-                instance.share(),
-                false,
-                InternalMode::INTERNAL_MODE_DISABLED,
+                instance.clone(),
             ),
             None => {
                 tracing::error!("attempted to add a child to the BevyAppSingleton autoload, but the BevyAppSingleton autoload wasn't found");
@@ -143,13 +146,13 @@ fn spawn_scene(
         if let Some(transform) = &scene.transform {
             match transform {
                 GodotSceneTransform::Transform2D(transform) => {
-                    match instance.share().try_cast::<Node2D>() {
+                    match instance.clone().try_cast::<Node2D>().ok() {
                         Some(mut node2d) => node2d.set_global_transform(*transform),
                         None => tracing::error!("attempted to spawn a scene with a transform on Node that did not inherit from Node3D, the transform was not set"),
                     }
                 }
                 GodotSceneTransform::Transform3D(transform) => {
-                    match instance.share().try_cast::<Node3D>() {
+                    match instance.clone().try_cast::<Node3D>().ok() {
                         Some(mut node3d) => node3d.set_global_transform(*transform),
                         None => tracing::error!("attempted to spawn a scene with a transform on Node that did not inherit from Node3D, the transform was not set"),
                     }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -107,11 +107,7 @@ fn spawn_scene(
             GodotSceneResource::Resource(res) => res.get(),
             GodotSceneResource::Path(path) => ResourceLoader::singleton()
                 .load(
-                    // path.into(),
-                    // "PackedScene".into(),
                     GString::from_str(path).expect("path to be a valid GString"),
-                    // // CacheMode::CACHE_MODE_REUSE,
-                    // CacheMode::REUSE,
                 )
                 .expect("packed scene to load"),
             #[cfg(feature = "assets")]
@@ -124,7 +120,6 @@ fn spawn_scene(
         let instance = packed_scene
             .try_cast::<PackedScene>()
             .expect("resource to be a packed scene")
-            // .instantiate(GenEditState::GEN_EDIT_STATE_DISABLED)
             .instantiate()
             .unwrap();
 

--- a/src/scene_tree.rs
+++ b/src/scene_tree.rs
@@ -12,7 +12,7 @@ pub struct SceneTreeRef<'w, 's> {
 
 impl<'w, 's> SceneTreeRef<'w, 's> {
     pub fn get(&mut self) -> Gd<SceneTree> {
-        self.gd.0.share()
+        self.gd.0.clone()
     }
 }
 

--- a/src/scene_tree.rs
+++ b/src/scene_tree.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use bevy::ecs::system::SystemParam;
-use godot::engine::Engine;
+use godot::classes::Engine;
 use std::marker::PhantomData;
 
 #[derive(SystemParam)]

--- a/src/scene_tree.rs
+++ b/src/scene_tree.rs
@@ -1,6 +1,8 @@
-use crate::prelude::*;
-use bevy::ecs::system::SystemParam;
-use godot::classes::Engine;
+use bevy::{ecs::system::SystemParam, prelude::NonSendMut};
+use godot::{
+    classes::{Engine, SceneTree},
+    obj::Gd,
+};
 use std::marker::PhantomData;
 
 #[derive(SystemParam)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    ecs::{schedule::SystemConfig, system::SystemParam},
+    ecs::{schedule::{SystemConfig, SystemConfigs}, system::SystemParam},
     prelude::*,
 };
 use std::{
@@ -18,26 +18,26 @@ pub struct GodotPhysicsFrame;
 /// Adds `as_physics_system` that schedules a system only for the physics frame
 pub trait AsPhysicsSystem<Params> {
     #[allow(clippy::wrong_self_convention)]
-    fn as_physics_system(self) -> SystemConfig;
+    fn as_physics_system(self) -> SystemConfigs;
 }
 
 impl<Params, T: IntoSystem<(), (), Params>> AsPhysicsSystem<Params> for T {
-    fn as_physics_system(self) -> SystemConfig {
-        self.run_if(resource_exists::<GodotPhysicsFrame>())
+    fn as_physics_system(self) -> SystemConfigs {
+        self.run_if(resource_exists::<GodotPhysicsFrame>)
     }
 }
 
 /// Adds `as_visual_system` that schedules a system only for the frame
 pub trait AsVisualSystem<Params> {
     #[allow(clippy::wrong_self_convention)]
-    fn as_visual_system(self) -> SystemConfig;
+    fn as_visual_system(self) -> SystemConfigs;
 }
 
-impl<Params, T: IntoSystem<(), (), Params>> AsVisualSystem<Params> for T {
-    fn as_visual_system(self) -> SystemConfig {
-        self.run_if(resource_exists::<GodotVisualFrame>())
-    }
-}
+// impl<Params, T: IntoSystem<(), (), Params>> AsVisualSystem<Params> for T {
+//     fn as_visual_system(self) -> SystemConfig {
+//         self.run_if(resource_exists::<GodotVisualFrame>)
+//     }
+// }
 
 /// SystemParam to keep track of an independent delta time
 ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    ecs::{schedule::{SystemConfig, SystemConfigs}, system::SystemParam},
+    ecs::{schedule::SystemConfigs, system::SystemParam},
     prelude::*,
 };
 use std::{

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,11 +33,11 @@ pub trait AsVisualSystem<Params> {
     fn as_visual_system(self) -> SystemConfigs;
 }
 
-// impl<Params, T: IntoSystem<(), (), Params>> AsVisualSystem<Params> for T {
-//     fn as_visual_system(self) -> SystemConfig {
-//         self.run_if(resource_exists::<GodotVisualFrame>)
-//     }
-// }
+impl<Params, T: IntoSystem<(), (), Params>> AsVisualSystem<Params> for T {
+    fn as_visual_system(self) -> SystemConfigs {
+        self.run_if(resource_exists::<GodotVisualFrame>)
+    }
+}
 
 /// SystemParam to keep track of an independent delta time
 ///


### PR DESCRIPTION
This PR fixes the remaining issues from the awesome PR #2 by @funatsufumiya 

It bumps the `bevy` version to `0.14` and uses the newly available crates.io version of `gdext` instead of pointing towards the git repo.

Note that the `bevy_godot4::prelude` no longer imports `bevy::prelude` and `godot::prelude` modules, since that lead to a name clash of their individual `Resource` structs. (This is potentially a slight breaking change, but should prevent similar issues in the future.)

Successfully tested on Arch Linux (`rustc 1.80.1 (3f5fd8dd4 2024-08-06)`) and Windows 10.
