### PR TITLE
Github version of gdext doesn't generate BevyApp Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ The architecture in this crate mimics that of [bevy_godot](https://github.com/ra
 
 1. Follow the steps outlined in the [GDExtension Getting Started](https://github.com/godot-rust/gdext#getting-started).
 
-2. Add this line to your cargo dependencies (along with the godot dependency from GDExtension setup):
+2. Add this line to your cargo dependencies (along with the godot dependency from GDExtension setup):  
+❗ Consieder using crates.io version of the [godot](https://crates.io/crates/godot) crate, and not the github one ❗
 ```
 [dependencies]
-godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }
+godot = "0.1.3"
 bevy_godot4 = { git = "https://github.com/jrockett6/bevy_godot4", branch = "main" }
 ```
 3. Create a function that takes a `&mut App` and builds your bevy app, and annotate it with `#[bevy_app]`:


### PR DESCRIPTION
According to the 2nd step of the [Setup](https://github.com/jrockett6/bevy_godot4?tab=readme-ov-file#setup) section in the readme file – you could use the github link to the dgext crate for dependency  
```toml
[dependencies]
godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }
```

but, at least in my case (linux, godot 4.3) – it just doesn't work, cuz the `BevyApp` node just won't appear! even considering that the gdextension is set up correctly, for example: i **could** write this code and the `Player` node will work just fine!
```rust
#[derive(GodotClass)]
#[class(base=Sprite2D)]
struct Player {
    speed: f64,
    angular_speed: f64,

    base: Base<Sprite2D>,
}

#[godot_api]
impl ISprite2D for Player {
    fn init(base: Base<Sprite2D>) -> Self {
        Self {
            speed: 400.0,
            angular_speed: std::f64::consts::PI,
            base,
        }
    }
}
```

meanwhile the [simple example](https://github.com/jrockett6/bevy_godot4/tree/main/examples/simple) uses crates.io version of the godot crate as dependency. so did i, and it just works!
```toml
[dependencies]
godot = "0.1.3"
```