### PR TITLE
fix BevyApp not being initialized in builds

### DIFF
--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -12,7 +12,7 @@ pub fn bevy_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #[gdextension]
         unsafe impl ExtensionLibrary for BevyExtensionLibrary {
             fn on_level_init(level: godot::prelude::InitLevel) {
-                if level == godot::prelude::InitLevel::Editor {
+                if level == godot::prelude::InitLevel::Core {
                     godot::private::class_macros::registry::class::auto_register_classes(level);
                     let mut app_builder_func = bevy_godot4::APP_BUILDER_FN.lock().unwrap();
                     if app_builder_func.is_none() {


### PR DESCRIPTION
This PR fixes the BevyApp only being initialized in Editor.