### PR TITLE
Update the project to support Bevy 0.15 & latest godot-rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_godot4"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]
@@ -12,8 +12,8 @@ assets = [] # experimental feature, see assets::GodotResourceLoader
 
 [dependencies]
 anyhow = "1"
-bevy = { version = "0.14", default-features = false, features = ["bevy_asset"] }
-godot = "0.1.3"
+bevy = { version = "0.15", default-features = false, features = ["bevy_asset"] }
+godot = "0.2.4"
 bevy_godot4_proc_macros = { path = "./proc_macros" }
 lazy_static = "1.4.0"
 send_wrapper = "0.6"

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -111,7 +111,7 @@ fn spawn_scene(
         let packed_scene = match &mut scene.resource {
             GodotSceneResource::Resource(res) => res.get(),
             GodotSceneResource::Path(path) => ResourceLoader::singleton()
-                .load(GString::from_str(path).expect("path to be a valid GString"))
+                .load(&GString::from_str(path).expect("path to be a valid GString"))
                 .expect("packed scene to load"),
             #[cfg(feature = "assets")]
             GodotSceneResource::Handle(handle) => assets
@@ -130,9 +130,9 @@ fn spawn_scene(
             .get()
             .get_root()
             .unwrap()
-            .get_node_or_null("BevyAppSingleton".into())
+            .get_node_or_null("BevyAppSingleton")
         {
-            Some(mut app) => app.add_child(instance.clone()),
+            Some(mut app) => app.add_child(&instance),
             None => {
                 tracing::error!("attempted to add a child to the BevyAppSingleton autoload, but the BevyAppSingleton autoload wasn't found");
                 return;


### PR DESCRIPTION
Updated to the latest godot-rust (0.24) and Bevy 0.15, bumps SemVer to 0.2.0 to reflect.

Went easier than expected! At a glance I don't see anything in the wrapper logic that would break with the version bump. 

The small changes in scene.rs were required to get newer godot-rust working, new Bevy worked on top of that straight away.