### PR TITLE
Migrating to Bevy 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_godot4"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_godot4"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [lib]
@@ -12,8 +12,8 @@ assets = [] # experimental feature, see assets::GodotResourceLoader
 
 [dependencies]
 anyhow = "1"
-bevy = { version = "0.15", default-features = false, features = ["bevy_asset"] }
+bevy = { version = "0.16", default-features = false, features = ["bevy_asset", "bevy_log"] }
 godot = "0.2.4"
 bevy_godot4_proc_macros = { path = "./proc_macros" }
-lazy_static = "1.4.0"
+lazy_static = "1.5.0"
 send_wrapper = "0.6"

--- a/README.md
+++ b/README.md
@@ -13,12 +13,21 @@ The architecture in this crate is based on [bevy_godot](https://github.com/rand0
 
 1. Follow the steps outlined in the [GDExtension Getting Started](https://godot-rust.github.io/book/intro/index.html).
 
-2. Add this library as a dependency (along with the GDExtension godot crate):  
-```
+2. Add this library as a dependency (along with the GDExtension godot crate):
+```toml
 [dependencies]
+bevy = { version = "0.16", default-features = false, features = [
+    "bevy_asset",
+    "bevy_state",
+] }
 bevy_godot4 = { git = "https://github.com/jrockett6/bevy_godot4", branch = "main" }
-godot = "0.1.3"
+godot = "0.2.4"
 ```
+
+> **_NOTE:_** You can, of course, enable other features in `bevy`; in the above
+> example, we've simply minimized our feature set in order to minimize compile
+> times and built-artifact size.
+
 3. Create a function that takes a `&mut App` and builds your bevy app, and annotate it with `#[bevy_app]`:
 ```rust
 #[bevy_app]
@@ -26,9 +35,18 @@ fn build_app(app: &mut App) {
     app.add_system(my_system)
 }
 ```
-4. Cargo build your project, and make sure the dll is found by Godot via the .gdextension file. You should now have the `BevyApp` Node avaiable to you in the Godot editor (you may need to refresh the project in the editor). 
+
+4. Cargo build your project, and make sure the dll is found by Godot via the .gdextension file. You should now have the `BevyApp` Node avaiable to you in the Godot editor (you may need to refresh the project in the editor).
 
 5. Add this `BevyApp` Node as a Godot autoload named `BevyAppSingleton` in the Godot project settings.
+
+## Version Compatibility Matrix
+
+| Godot-Bevy | Bevy | Godot-Rust | Godot |
+|------------|------|------------|-------|
+| 0.2.x      | 0.15 | 0.2.4      | 4.4.x |
+| 0.3.x      | 0.16 | 0.2.4      | 4.4.x |
+
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ fn build_app(app: &mut App) {
 
 ## Version Compatibility Matrix
 
-| Godot-Bevy | Bevy | Godot-Rust | Godot |
-|------------|------|------------|-------|
-| 0.2.x      | 0.15 | 0.2.4      | 4.4.x |
-| 0.3.x      | 0.16 | 0.2.4      | 4.4.x |
+| bevy_godot4 | Bevy | Godot-Rust | Godot |
+|-------------|------|------------|-------|
+| 0.2.x       | 0.15 | 0.2.4      | 4.4.x |
+| 0.3.x       | 0.16 | 0.2.4      | 4.4.x |
 
 
 ## Features
@@ -106,11 +106,3 @@ fn my_main_thread_system(
 ```
 
 *Checkout the examples folder for more.*
-
-
-
-
-
-
-
-

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
   "simple"
 ]
+resolver = "3"

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "simple"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [[bin]]

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -12,7 +12,7 @@ name = "simple"
 crate-type = ["cdylib"]
 
 [dependencies]
-bevy = { version = "0.15.3", default-features = false, features = [
+bevy = { version = "0.16", default-features = false, features = [
     "bevy_asset",
     "bevy_state",
 ] }

--- a/examples/simple/godot/main.tscn
+++ b/examples/simple/godot/main.tscn
@@ -1,4 +1,3 @@
 [gd_scene format=3 uid="uid://dvaikj6lrfk3e"]
 
 [node name="Node2D" type="Node2D"]
-position = Vector2(1, 0)

--- a/examples/simple/src/lib.rs
+++ b/examples/simple/src/lib.rs
@@ -1,13 +1,11 @@
 use bevy::{
     app::{App, Update},
-    ecs::system::Res,
-    prelude::{
-        in_state, AppExtStates, Commands, IntoSystemConfigs, OnEnter, Query, Resource, States,
-    },
+    ecs::{schedule::IntoScheduleConfigs, system::Res},
+    prelude::{AppExtStates, Commands, OnEnter, Query, Resource, States, in_state},
     state::app::StatesPlugin,
 };
 use bevy_godot4::prelude::{
-    bevy_app, AsPhysicsSystem, ErasedGd, ErasedGdResource, GodotScene, SystemDeltaTimer,
+    AsPhysicsSystem, ErasedGd, ErasedGdResource, GodotScene, SystemDeltaTimer, bevy_app,
 };
 use godot::{
     builtin::Vector2,
@@ -57,7 +55,7 @@ fn spawn_sprite(mut commands: Commands, assets: Res<MyAssets>) {
 }
 
 fn move_sprite(mut sprite: Query<&mut ErasedGd>, mut delta: SystemDeltaTimer) {
-    if let Ok(mut sprite) = sprite.get_single_mut() {
+    if let Ok(mut sprite) = sprite.single_mut() {
         let mut sprite = sprite.get::<Sprite2D>();
         let delta = delta.delta_seconds() * 20.0;
         let position = sprite.get_position();

--- a/proc_macros/Cargo.toml
+++ b/proc_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_godot4_proc_macros"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 proc-macro = true

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,12 +2,12 @@ use bevy::app::App;
 use godot::{
     classes::{INode, Node},
     obj::Base,
-    prelude::{godot_api, GodotClass},
+    prelude::{GodotClass, godot_api},
 };
 
 use crate::prelude::*;
 use std::{
-    panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
+    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     sync::Mutex,
 };
 
@@ -45,13 +45,11 @@ impl INode for BevyApp {
 
         let mut app = App::new();
         (APP_BUILDER_FN.lock().unwrap().as_mut().unwrap())(&mut app);
-        app.add_plugins(bevy::core::TaskPoolPlugin::default())
+        app.add_plugins(bevy::app::TaskPoolPlugin::default())
             .add_plugins(bevy::log::LogPlugin::default())
-            .add_plugins(bevy::core::TypeRegistrationPlugin)
-            .add_plugins(bevy::core::FrameCountPlugin)
+            .add_plugins(bevy::diagnostic::FrameCountPlugin)
             .add_plugins(bevy::diagnostic::DiagnosticsPlugin)
             .add_plugins(bevy::time::TimePlugin)
-            .add_plugins(bevy::hierarchy::HierarchyPlugin)
             .add_plugins(crate::scene::PackedScenePlugin)
             .init_non_send_resource::<crate::scene_tree::SceneTreeRefImpl>();
         // .add_plugins(GodotSignalsPlugin)

--- a/src/erased_gd.rs
+++ b/src/erased_gd.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::Component;
 use godot::{
     classes::{Node, Object, Resource},
-    obj::{bounds::DynMemory, Bounds, Gd, GodotClass, Inherits, InstanceId, RawGd},
+    obj::{Bounds, Gd, GodotClass, Inherits, InstanceId, RawGd, bounds::DynMemory},
     sys,
 };
 
@@ -86,7 +86,7 @@ impl Clone for ErasedGdResource {
         maybe_inc_ref_opt::<Resource>(&mut Gd::try_from_instance_id(self.resource_id).ok());
 
         Self {
-            resource_id: self.resource_id.clone(),
+            resource_id: self.resource_id,
         }
     }
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -3,8 +3,8 @@ use std::str::FromStr;
 use crate::prelude::*;
 use bevy::{
     app::{App, Plugin, PostUpdate},
+    log::tracing,
     prelude::{Commands, Component, Entity, Query, Without},
-    utils::tracing,
 };
 use godot::{
     builtin::{GString, Transform2D, Transform3D, Vector2, Vector3},
@@ -134,7 +134,9 @@ fn spawn_scene(
         {
             Some(mut app) => app.add_child(&instance),
             None => {
-                tracing::error!("attempted to add a child to the BevyAppSingleton autoload, but the BevyAppSingleton autoload wasn't found");
+                tracing::error!(
+                    "attempted to add a child to the BevyAppSingleton autoload, but the BevyAppSingleton autoload wasn't found"
+                );
                 return;
             }
         }
@@ -144,13 +146,17 @@ fn spawn_scene(
                 GodotSceneTransform::Transform2D(transform) => {
                     match instance.clone().try_cast::<Node2D>().ok() {
                         Some(mut node2d) => node2d.set_global_transform(*transform),
-                        None => tracing::error!("attempted to spawn a scene with a transform on Node that did not inherit from Node3D, the transform was not set"),
+                        None => tracing::error!(
+                            "attempted to spawn a scene with a transform on Node that did not inherit from Node3D, the transform was not set"
+                        ),
                     }
                 }
                 GodotSceneTransform::Transform3D(transform) => {
                     match instance.clone().try_cast::<Node3D>().ok() {
                         Some(mut node3d) => node3d.set_global_transform(*transform),
-                        None => tracing::error!("attempted to spawn a scene with a transform on Node that did not inherit from Node3D, the transform was not set"),
+                        None => tracing::error!(
+                            "attempted to spawn a scene with a transform on Node that did not inherit from Node3D, the transform was not set"
+                        ),
                     }
                 }
             }

--- a/src/scene_tree.rs
+++ b/src/scene_tree.rs
@@ -8,11 +8,10 @@ use std::marker::PhantomData;
 #[derive(SystemParam)]
 pub struct SceneTreeRef<'w, 's> {
     gd: NonSendMut<'w, SceneTreeRefImpl>,
-    #[system_param(ignore)]
     phantom: PhantomData<&'s ()>,
 }
 
-impl<'w, 's> SceneTreeRef<'w, 's> {
+impl SceneTreeRef<'_, '_> {
     pub fn get(&mut self) -> Gd<SceneTree> {
         self.gd.0.clone()
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,8 @@
 use bevy::{
-    ecs::{schedule::SystemConfigs, system::SystemParam},
+    ecs::{
+        schedule::ScheduleConfigs,
+        system::{ScheduleSystem, SystemParam},
+    },
     prelude::*,
 };
 use std::{
@@ -18,11 +21,11 @@ pub struct GodotPhysicsFrame;
 /// Adds `as_physics_system` that schedules a system only for the physics frame
 pub trait AsPhysicsSystem<Params> {
     #[allow(clippy::wrong_self_convention)]
-    fn as_physics_system(self) -> SystemConfigs;
+    fn as_physics_system(self) -> ScheduleConfigs<ScheduleSystem>;
 }
 
 impl<Params, T: IntoSystem<(), (), Params>> AsPhysicsSystem<Params> for T {
-    fn as_physics_system(self) -> SystemConfigs {
+    fn as_physics_system(self) -> ScheduleConfigs<ScheduleSystem> {
         self.run_if(resource_exists::<GodotPhysicsFrame>)
     }
 }
@@ -30,11 +33,11 @@ impl<Params, T: IntoSystem<(), (), Params>> AsPhysicsSystem<Params> for T {
 /// Adds `as_visual_system` that schedules a system only for the frame
 pub trait AsVisualSystem<Params> {
     #[allow(clippy::wrong_self_convention)]
-    fn as_visual_system(self) -> SystemConfigs;
+    fn as_visual_system(self) -> ScheduleConfigs<ScheduleSystem>;
 }
 
 impl<Params, T: IntoSystem<(), (), Params>> AsVisualSystem<Params> for T {
-    fn as_visual_system(self) -> SystemConfigs {
+    fn as_visual_system(self) -> ScheduleConfigs<ScheduleSystem> {
         self.run_if(resource_exists::<GodotVisualFrame>)
     }
 }
@@ -46,11 +49,10 @@ impl<Params, T: IntoSystem<(), (), Params>> AsVisualSystem<Params> for T {
 #[derive(SystemParam)]
 pub struct SystemDeltaTimer<'w, 's> {
     last_time: Local<'s, Option<Instant>>,
-    #[system_param(ignore)]
     marker: PhantomData<&'w ()>,
 }
 
-impl<'w, 's> SystemDeltaTimer<'w, 's> {
+impl SystemDeltaTimer<'_, '_> {
     /// Returns the time passed since the last invocation
     pub fn delta(&mut self) -> Duration {
         let now = Instant::now();


### PR DESCRIPTION
Migrating to Bevy 0.16

* Some useful references that informed changes:
  * https://bevyengine.org/learn/migration-guides/0-15-to-0-16/
  * https://github.com/bevyengine/bevy/pull/8265
* Cargo clippy fix over all code
* Updated simple example so it works with Bevy 0.16
* Update rust edition to 2024, fix simple example resolver warning
